### PR TITLE
refactor: Inject the template cache into renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ swift build
 - [ ] Consider supporting filters in the `set` tag
 - [ ] Consider special files in directories for nested behaviours
 - [ ] Log at at different levels, error, warning, etc
+- [ ] Rename page to document in the render context

--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -27,7 +27,7 @@ struct Document {
     let url: String
     let parent: String
     let type: String  // TODO: Is this really the type? I think it might be the category? Needs renaming?
-    let date: Date?  // TODO: Perhaps this needs to be the file mtime?
+    let date: Date?
     let metadata: [AnyHashable: Any]
     let contents: String
     let contentModificationDate: Date

--- a/Sources/InContextError.swift
+++ b/Sources/InContextError.swift
@@ -24,7 +24,7 @@ import Foundation
 
 enum InContextError: Error {
     case unsupportedEncoding
-    case unknown
+    case unknown  // TODO: Remove this.
     case internalInconsistency(String)
     case unknownSymbol(String)
     case invalidKey(Any?)

--- a/Sources/Renderers/IdentityRenderer.swift
+++ b/Sources/Renderers/IdentityRenderer.swift
@@ -25,8 +25,13 @@ import Foundation
 // Demo renderer that outputs the contents of the document.
 class IdentityRenderer: Renderer {
 
-    func render(_ name: String, context: [String : Any]) async throws -> RenderResult {
-        // TODO: Rename page to document?
+    let templateCache: TemplateCache
+
+    init(templateCache: TemplateCache) {
+        self.templateCache = templateCache
+    }
+
+    func render(name: String, context: [String : Any]) async throws -> RenderResult {
         guard let page = context["page"] as? DocumentContext else {
             throw InContextError.internalInconsistency("Unable to get 'page' from render context.")
         }

--- a/Sources/Renderers/RenderManager.swift
+++ b/Sources/Renderers/RenderManager.swift
@@ -1,0 +1,63 @@
+// MIT License
+//
+// Copyright (c) 2023 Jason Barrie Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+class RenderManager {
+
+    let templateCache: TemplateCache
+    let renderers: [TemplateLanguage: Renderer]
+
+    init(templateCache: TemplateCache) {
+        self.templateCache = templateCache
+        self.renderers = [
+            .identity: IdentityRenderer(templateCache: templateCache),
+            .stencil: StencilRenderer(templateCache: templateCache),
+            .tilt: TiltRenderer(templateCache: templateCache),
+        ]
+    }
+
+    func render(templateTracker: TemplateTracker,
+                identifier: TemplateIdentifier,
+                context: [String: Any]) async throws -> String {
+
+        guard let renderer = renderers[identifier.language] else {
+            throw InContextError.internalInconsistency("Failed to get renderer for language '\(identifier.language)'.")
+        }
+
+        let renderResult = try await renderer.render(name: identifier.name, context: context)
+
+        // Generate the TemplateStatus tuples with the template content modification times.
+        let templatesUsed: [TemplateIdentifier] = renderResult.templatesUsed.map { name in
+            return TemplateIdentifier(identifier.language, name)
+        }
+
+        for identifier in templatesUsed {
+            guard let modificationDate = templateCache.modificationDate(for: identifier) else {
+                throw InContextError.internalInconsistency("Failed to get content modification date for template '\(identifier)'.")
+            }
+            templateTracker.add(TemplateStatus(identifier: identifier, modificationDate: modificationDate))
+        }
+        return renderResult.content
+    }
+
+}

--- a/Sources/Renderers/Renderer.swift
+++ b/Sources/Renderers/Renderer.swift
@@ -24,6 +24,6 @@ import Foundation
 
 protocol Renderer {
 
-    func render(_ name: String, context: [String: Any]) async throws -> RenderResult
+    func render(name: String, context: [String: Any]) async throws -> RenderResult
 
 }

--- a/Sources/Renderers/StencilRenderer.swift
+++ b/Sources/Renderers/StencilRenderer.swift
@@ -150,7 +150,7 @@ class StencilRenderer: Renderer {
         self.environment = Environment(loader: loader, extensions: [Self.stencilExtension()])
     }
 
-    func render(_ name: String, context: [String : Any]) async throws -> RenderResult {
+    func render(name: String, context: [String : Any]) async throws -> RenderResult {
         // TODO: Is it possible to track the templates used externally?
         let (content, templates) = try environment.renderTemplate(name: name, context: context)
         return RenderResult(content: content, templatesUsed: templates)

--- a/Sources/Renderers/TiltRenderer.swift
+++ b/Sources/Renderers/TiltRenderer.swift
@@ -24,7 +24,13 @@ import Foundation
 
 class TiltRenderer: Renderer {
 
-    func render(_ name: String, context: [String : Any]) async throws -> RenderResult {
+    let templateCache: TemplateCache
+
+    init(templateCache: TemplateCache) {
+        self.templateCache = templateCache
+    }
+
+    func render(name: String, context: [String : Any]) async throws -> RenderResult {
         // Trivial. Left as an exercise for the reader.
         return RenderResult(content: "", templatesUsed: [])
     }

--- a/Sources/Stencil/CachingLoader.swift
+++ b/Sources/Stencil/CachingLoader.swift
@@ -27,7 +27,7 @@ import Stencil
 class CachingLoader: Loader {
 
     let templateCache: TemplateCache
-    var cache: [String: Template] = [:]
+    let cache = Cache<String, Template>()
 
     init(templateCache: TemplateCache) {
         self.templateCache = templateCache

--- a/Sources/TemplateDetails.swift
+++ b/Sources/TemplateDetails.swift
@@ -22,11 +22,11 @@
 
 import Foundation
 
-// TODO: Include the renderer version. It's currently unclear to me if this needs to be bound to the top-level result or
-//       to each template individually.
-struct RenderResult {
+struct TemplateDetails: Hashable {
 
-    let content: String
-    let templatesUsed: [String]
+    let url: URL
+    let language: TemplateLanguage
+    let modificationDate: Date
+    let contents: String
 
 }

--- a/Sources/TemplateStatus.swift
+++ b/Sources/TemplateStatus.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-struct TemplateStatus: Codable {
+struct TemplateStatus: Codable, Hashable {
 
     let identifier: TemplateIdentifier
     let modificationDate: Date

--- a/Sources/TemplateTracker.swift
+++ b/Sources/TemplateTracker.swift
@@ -22,11 +22,19 @@
 
 import Foundation
 
-// TODO: Include the renderer version. It's currently unclear to me if this needs to be bound to the top-level result or
-//       to each template individually.
-struct RenderResult {
+class TemplateTracker {
 
-    let content: String
-    let templatesUsed: [String]
+    private var statuses = Set<TemplateStatus>()
+
+    init() {
+    }
+
+    func add(_ templateStatus: TemplateStatus) {
+        statuses.insert(templateStatus)
+    }
+
+    func result() -> [TemplateStatus] {
+        return Array(statuses)
+    }
 
 }


### PR DESCRIPTION
This change also introduces a top-level `RenderManager` which is responsible for dispatching renders to different `Renderer` instances.