### PR TITLE
fix: Replace `InContextError.unknown` with more informative errors

### DIFF
--- a/Sources/Builder.swift
+++ b/Sources/Builder.swift
@@ -136,22 +136,22 @@ class Builder {
             }
         ]
 
-        // TODO: Rename this to something more like a render tracker?
-        // TODO: Perhaps the store can be injected into the render tracker too to make it all nice and clean?
-        let templateTracker = TemplateTracker()
-        let content = try await renderManager.render(templateTracker: templateTracker,
+        // TODO: Consolidate RenderTracker and QueryTracker
+        //       RenderTracker(for document: Document)?
+        let renderTracker = RenderTracker()
+        let content = try await renderManager.render(renderTracker: renderTracker,
                                                      template: document.template,
                                                      context: context)
         let renderStatus = RenderStatus(contentModificationDate: document.contentModificationDate,
                                         queries: queryTracker.queries,
-                                        renderers: templateTracker.renderers(),
-                                        templates: templateTracker.statuses())
+                                        renderers: renderTracker.renderers(),
+                                        templates: renderTracker.statuses())
         try await store.save(renderStatus: renderStatus, for: document.url)
 
         // Write the contents to a file.
         try FileManager.default.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
         guard let data = content.data(using: .utf8) else {
-            throw InContextError.unsupportedEncoding
+            throw InContextError.encodingError
         }
         try data.write(to: destinationFileURL)
     }

--- a/Sources/Extensions/Array.swift
+++ b/Sources/Extensions/Array.swift
@@ -32,8 +32,7 @@ extension Array: EvaluationContext {
         }
         case "have_dates": return Function { (haveDates: Bool) -> [DocumentContext]  in
             guard let documents = self as? [DocumentContext] else {
-                // TODO: Invalid type.
-                throw InContextError.unknown
+                throw InContextError.internalInconsistency("'have_dates' is only supported on an array of documents.")
             }
             return documents.filter { document in
                 return haveDates ? document.date != nil : document.date == nil

--- a/Sources/Extensions/String.swift
+++ b/Sources/Extensions/String.swift
@@ -31,7 +31,7 @@ extension String: EvaluationContext {
         case "count":
             return count
         default:
-            throw InContextError.unknown
+            throw InContextError.unknownSymbol(name)
         }
     }
 

--- a/Sources/Importers/ImageImporter.swift
+++ b/Sources/Importers/ImageImporter.swift
@@ -70,7 +70,7 @@ class ImageImporter: Importer {
 
         // Load the original image.
         guard let image = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
-            throw InContextError.unknown
+            throw InContextError.internalInconsistency("Failed to open image file at '\(fileURL.relativePath)'.")
         }
 
         // TODO: Extract some of this data into the document.
@@ -78,7 +78,7 @@ class ImageImporter: Importer {
         guard let properties = CGImageSourceCopyPropertiesAtIndex(image, 0, nil) as? [String: Any],
               let width = properties["PixelWidth"] as? Int,
               let height = properties["PixelHeight"] as? Int else{
-            throw InContextError.unknown
+            throw InContextError.internalInconsistency("Filed to get dimensions of image at \(fileURL.relativePath).")
         }
 
         // TODO: Calculate the aspect ratio etc.
@@ -111,7 +111,7 @@ class ImageImporter: Importer {
                                                                     transform.format.identifier as CFString,
                                                                     1,
                                                                     nil) else {
-                throw InContextError.unknown
+                throw InContextError.internalInconsistency("Failed to resize image at '\(fileURL.relativePath)'.")
             }
             CGImageDestinationAddImage(destination, thumbnail, nil)
             CGImageDestinationFinalize(destination)  // TODO: Handle error here?

--- a/Sources/Importers/MarkdownImporter.swift
+++ b/Sources/Importers/MarkdownImporter.swift
@@ -52,7 +52,7 @@ class MarkdownImporter: Importer {
 
         let data = try Data(contentsOf: fileURL)
         guard let contents = String(data: data, encoding: .utf8) else {
-            throw InContextError.unsupportedEncoding
+            throw InContextError.encodingError
         }
         let details = fileURL.basenameDetails()
 

--- a/Sources/InContextError.swift
+++ b/Sources/InContextError.swift
@@ -23,8 +23,7 @@
 import Foundation
 
 enum InContextError: Error {
-    case unsupportedEncoding
-    case unknown  // TODO: Remove this.
+    case encodingError
     case internalInconsistency(String)
     case unknownSymbol(String)
     case invalidKey(Any?)
@@ -49,8 +48,6 @@ extension InContextError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .unknown:
-            return "Unknown error."
         case .unknownTemplate(let name):
             return "Unknown template '\(name)'."
         case .internalInconsistency(let message):

--- a/Sources/RenderTracker.swift
+++ b/Sources/RenderTracker.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-class TemplateTracker {
+class RenderTracker {
 
     private var _renderers = Set<RendererInstance>()
     private var _statuses = Set<TemplateRenderStatus>()

--- a/Sources/Renderers/RenderManager.swift
+++ b/Sources/Renderers/RenderManager.swift
@@ -43,7 +43,7 @@ class RenderManager {
         return renderer
     }
 
-    func render(templateTracker: TemplateTracker,
+    func render(renderTracker: RenderTracker,
                 template: TemplateIdentifier,
                 context: [String: Any]) async throws -> String {
         let renderer = try renderer(for: template.language)
@@ -54,7 +54,7 @@ class RenderManager {
         // Record the renderer instance used.
         // It is sufficient to record this once for the whole render operation even though multiple templates might be
         // used, as we do not allow mixing of template languages within a single top-level render.
-        templateTracker.add(RendererInstance(language: template.language, version: renderer.version))
+        renderTracker.add(RendererInstance(language: template.language, version: renderer.version))
 
         // Generate language-scoped identifiers for the templates reported as used by the renderer.
         let templatesUsed: [TemplateIdentifier] = renderResult.templatesUsed.map { name in
@@ -67,7 +67,7 @@ class RenderManager {
             guard let modificationDate = templateCache.modificationDate(for: template) else {
                 throw InContextError.internalInconsistency("Failed to get content modification date for template '\(template)'.")
             }
-            templateTracker.add(TemplateRenderStatus(identifier: template, modificationDate: modificationDate))
+            renderTracker.add(TemplateRenderStatus(identifier: template, modificationDate: modificationDate))
         }
         return renderResult.content
     }

--- a/Sources/Renderers/StencilRenderer.swift
+++ b/Sources/Renderers/StencilRenderer.swift
@@ -119,8 +119,7 @@ class StencilRenderer: Renderer {
                 throw TemplateSyntaxError("'base64' filter expects a string")
             }
             guard let data = value.data(using: .utf8) else {
-                // TODO: Correct error
-                throw InContextError.unknown
+                throw InContextError.internalInconsistency("Failed to encode input as UTF8.")
             }
             return data.base64EncodedString()
         }
@@ -129,8 +128,7 @@ class StencilRenderer: Renderer {
             if let value = value as? NSNumber {
                 return value.intValue
             }
-            // TODO: Correct error.
-            throw InContextError.unknown
+            throw InContextError.internalInconsistency("Unable to cast \(String(describing: value)) to an integer.")
         }
 
         ext.registerTag("with", parser: WithNode.parse)

--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -57,7 +57,7 @@ struct Site {
         let settingsURL = rootURL.appendingPathComponent("site.yaml")
         let settingsData = try Data(contentsOf: settingsURL)
         guard let settingsString = String(data: settingsData, encoding: .utf8) else {
-            throw InContextError.unsupportedEncoding
+            throw InContextError.encodingError
         }
         self.settings = try (try Yaml.load(settingsString)).dictionary()
 

--- a/Sources/Stencil/Executable.swift
+++ b/Sources/Stencil/Executable.swift
@@ -59,8 +59,7 @@ extension Executable {
         if case .executable(let executable) = self.operand {
             return Self(operand: .executable(try executable.apply(to: operand)), operation: operation)
         }
-        // TODO: Invalid function application.
-        throw InContextError.unknown
+        throw InContextError.internalInconsistency("Invalid attempt to apply a literal as a function.")
     }
 
 }

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -169,8 +169,7 @@ class Store: Queryable {
                 // Serialise the metadata.
                 let data = try JSONSerialization.data(withJSONObject: document.metadata)
                 guard let metadata = String(data: data, encoding: .utf8) else {
-                    // TODO: Better error.
-                    throw InContextError.unknown
+                    throw InContextError.encodingError
                 }
 
                 try connection.run(Schema.documents.insert(or: .replace,
@@ -230,10 +229,9 @@ class Store: Queryable {
         guard let renderStatus = try connection.pluck(Schema.renderStatus.filter(Schema.url == url)) else {
             return nil
         }
-        // TODO: Check to see if this is costly to construct
         let decoder = JSONDecoder()
         guard let data = try renderStatus.get(Schema.details).data(using: .utf8) else {
-            throw InContextError.unknown
+            throw InContextError.encodingError
         }
         return try decoder.decode(RenderStatus.self, from: data)
     }
@@ -244,7 +242,7 @@ class Store: Queryable {
         return try rowIterator.map { row in
             let decoder = JSONDecoder()
             guard let data = row[Schema.details].data(using: .utf8) else {
-                throw InContextError.unknown
+                throw InContextError.encodingError
             }
             return (row[Schema.url], try decoder.decode(RenderStatus.self, from: data))
         }
@@ -258,8 +256,7 @@ class Store: Queryable {
             let encoder = JSONEncoder()
             let renderStatus = try encoder.encode(renderStatus)
             guard let string = String(data: renderStatus, encoding: .utf8) else {
-                // TODO: Decent error
-                throw InContextError.unknown
+                throw InContextError.encodingError
             }
 
             try connection.run(Schema.renderStatus.insert(or: .replace,
@@ -285,7 +282,7 @@ class Store: Queryable {
             guard let data = metadataString.data(using: .utf8),
                   let metadata = try JSONSerialization.jsonObject(with: data) as? [AnyHashable: Any]
             else {
-                throw InContextError.unknown
+                throw InContextError.internalInconsistency("Failed to load document metadata.")
             }
 
             // Template.


### PR DESCRIPTION
This change also includes a drive-by refactor to rename `TemplateTracker` to `RenderTracker`.