### PR TITLE
ci: Update GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,6 +92,7 @@ jobs:
 
     - name: Build the site
       run: |
+        ls **/*
         pushd build
         unzip artifact/incontext-*.zip
         popd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         submodules: recursive
@@ -46,7 +46,7 @@ jobs:
         scripts/build.sh
 
     - name: Archive the build directory
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: build
         if-no-files-found: error
@@ -57,7 +57,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         submodules: recursive
@@ -78,7 +78,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         submodules: recursive
@@ -86,7 +86,7 @@ jobs:
         lfs: true
 
     - name: Download the build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: build
 
@@ -105,7 +105,7 @@ jobs:
         done
 
     - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
 
   website-deploy:
     needs: website-build
@@ -123,7 +123,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   macos-update-homebrew:
     needs: macos-build
@@ -133,7 +133,7 @@ jobs:
     steps:
 
     - name: Update Homebrew formula
-      uses: peter-evans/repository-dispatch@v3
+      uses: peter-evans/repository-dispatch@v4
       with:
         token: ${{ secrets._GITHUB_ACCESS_TOKEN }}
         repository: inseven/homebrew-incontext
@@ -146,7 +146,7 @@ jobs:
     steps:
 
     - name: Update Sparkle archives
-      uses: peter-evans/repository-dispatch@v3
+      uses: peter-evans/repository-dispatch@v4
       with:
         token: ${{ secrets._GITHUB_ACCESS_TOKEN }}
         repository: inseven/sparkle-archives

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,9 +92,8 @@ jobs:
 
     - name: Build the site
       run: |
-        ls **/*
         pushd build
-        unzip artifact/incontext-*.zip
+        unzip incontext-*.zip
         popd
         build/incontext build --site docs
         mv docs/build/files _site


### PR DESCRIPTION
- `actions/checkout`: `v4` → `v6`
- `actions/upload-artifact`: `v4` → `v7`
- `actions/download-artifact`: `v4` → `v8`
- `actions/upload-pages-artifact`: `v3` → `v5`
- `actions/deploy-pages`: `v4` → `v5`
- `peter-evans/repository-dispatch`: `v3` → `v4`