### PR TITLE
fix: Use video metadata titles if present

### DIFF
--- a/Sources/InContextCore/Extensions/AVMetadataItem.swift
+++ b/Sources/InContextCore/Extensions/AVMetadataItem.swift
@@ -1,0 +1,50 @@
+// MIT License
+//
+// Copyright (c) 2016-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if !os(Linux)
+
+import AVFoundation
+import Foundation
+
+extension Array where Element == AVMetadataItem {
+
+   var quickTimeMetadataTitle: String? {
+       get async throws {
+           return try await AVMetadataItem.metadataItems(from: self,
+                                                         filteredByIdentifier: .quickTimeMetadataTitle)
+           .first?
+           .load(.stringValue)
+       }
+   }
+
+   var quickTimeMetadataDescription: String? {
+       get async throws {
+           return try await AVMetadataItem.metadataItems(from: self,
+                                                         filteredByIdentifier: .quickTimeMetadataDescription)
+           .first?
+           .load(.stringValue)
+       }
+   }
+
+}
+
+#endif

--- a/Sources/InContextCore/Importers/VideoImporterMac.swift
+++ b/Sources/InContextCore/Importers/VideoImporterMac.swift
@@ -39,13 +39,6 @@ extension VideoImporter: Importer {
 
         let asset = AVAsset(url: file.url)
 
-//        // Load the metadata.
-//        for format in try await asset.load(.availableMetadataFormats) {
-//            let metadata = try await asset.loadMetadata(for: format)
-//            print(metadata)
-//            // Process the format-specific metadata collection.
-//        }
-
         // Get the first track to guess the dimensions.
         let videoTracks = try await asset.load(.tracks).filter { track in
             return track.mediaType == .video
@@ -67,13 +60,12 @@ extension VideoImporter: Importer {
             date = nil
         }
 
-        let content: FrontmatterDocument?
-        if let descriptionItem = AVMetadataItem.metadataItems(from: quickTimeMetadata,
-                                                          filteredByIdentifier: .quickTimeMetadataDescription).first,
-           let description = try await descriptionItem.load(.stringValue) {
-            content = try FrontmatterDocument(contents: description, generateHTML: true)
+        // Get the metadata title and description.
+        let metadataTitle = try await quickTimeMetadata.quickTimeMetadataTitle
+        let content: FrontmatterDocument? = if let description = try await quickTimeMetadata.quickTimeMetadataDescription {
+            try FrontmatterDocument(contents: description, generateHTML: true)
         } else {
-            content = nil
+            nil
         }
 
         // TODO: Scale video.
@@ -118,11 +110,14 @@ extension VideoImporter: Importer {
             "video": videoDetails,
         ]
 
+        let filenameTitle = settings.titleFromFilename ? fileURL.basenameDetails().title : nil
+        let title = metadataTitle ?? content?.title ?? filenameTitle
+
         let document = try Document(url: fileURL.siteURL,
                                     parent: fileURL.parentURL,
                                     category: settings.defaultCategory,
                                     date: content?.date ?? date,
-                                    title: content?.title,
+                                    title: title,
                                     metadata: metadata,
                                     contents: content?.content ?? "",
                                     contentModificationDate: file.contentModificationDate,


### PR DESCRIPTION
This updates the video title handling to match the behavior for images.