### PR TITLE
fix: 🫧 Support HTML and markdown in headers

### DIFF
--- a/Sources/InContextCore/Extensions/String.swift
+++ b/Sources/InContextCore/Extensions/String.swift
@@ -23,6 +23,7 @@
 import Foundation
 
 import PlatformSupport
+import SwiftSoup
 
 extension String {
 
@@ -46,7 +47,14 @@ extension String {
     }
 
     func safeIdentifier() -> String? {
-        return lowercased()
+        guard let text = try? SwiftSoup.parseBodyFragment(self).text() else {
+            return nil
+        }
+        return text
+            .folding(options: .diacriticInsensitive, locale: nil)
+            .filter { $0.isASCII && ($0.isLetter || $0.isNumber || $0.isWhitespace || $0 == "-") }
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacing(/\s+/, with: "-")
     }
 

--- a/Tests/InContextTests/Tests/MarkdownTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownTests.swift
@@ -82,4 +82,45 @@ Text with footnote[^1].
 """)
     }
 
+    func testHeaderAnchorsStripFormatting() {
+        XCTAssertEqual("""
+# `Code` Header
+""".html(), """
+<h1><a id="code-header"></a><code>Code</code> Header</h1>
+
+""")
+    }
+
+    func testHeaderAnchorsStripUnicode() {
+        XCTAssertEqual("""
+# Café Rocket 🚀
+""".html(), """
+<h1><a id="cafe-rocket"></a>Café Rocket 🚀</h1>
+
+""")
+    }
+
+    func testHeaderAnchorsStripHTMLSignificantCharacters() {
+        XCTAssertEqual("""
+# Fish & Chips
+""".html(), """
+<h1><a id="fish-chips"></a>Fish &amp; Chips</h1>
+
+""")
+
+        XCTAssertEqual("""
+# 5 < 10
+""".html(), """
+<h1><a id="5-10"></a>5 &lt; 10</h1>
+
+""")
+
+        XCTAssertEqual("""
+# "Quoted" Header
+""".html(), """
+<h1><a id="quoted-header"></a>&quot;Quoted&quot; Header</h1>
+
+""")
+    }
+
 }

--- a/Tests/InContextTests/Tests/UtilityTests.swift
+++ b/Tests/InContextTests/Tests/UtilityTests.swift
@@ -36,4 +36,26 @@ class UtilityTests: XCTestCase {
         XCTAssertEqual("software/incontext/".pathDepth, 2)
     }
 
+    func testSafeIdentifier() {
+        XCTAssertEqual("Header".safeIdentifier(), "header")
+        XCTAssertEqual("Header 1".safeIdentifier(), "header-1")
+        XCTAssertEqual("Multiple   Spaces".safeIdentifier(), "multiple-spaces")
+        XCTAssertEqual("Tabs\tand\nNewlines".safeIdentifier(), "tabs-and-newlines")
+        XCTAssertEqual("  Leading and trailing  ".safeIdentifier(), "leading-and-trailing")
+        XCTAssertEqual("MixedCASE".safeIdentifier(), "mixedcase")
+        XCTAssertEqual("".safeIdentifier(), "")
+        XCTAssertEqual("<em>Header</em> 1".safeIdentifier(), "header-1")
+        XCTAssertEqual("<a href=\"https://example.com\">Header</a>".safeIdentifier(), "header")
+        XCTAssertEqual("Café".safeIdentifier(), "cafe")
+        XCTAssertEqual("Rocket 🚀 Launch".safeIdentifier(), "rocket-launch")
+        XCTAssertEqual("Fish & Chips".safeIdentifier(), "fish-chips")
+        XCTAssertEqual("5 < 10".safeIdentifier(), "5-10")
+        XCTAssertEqual("10 > 5".safeIdentifier(), "10-5")
+        XCTAssertEqual("\"Quoted\" Header".safeIdentifier(), "quoted-header")
+        XCTAssertEqual("It's a Test".safeIdentifier(), "its-a-test")
+        XCTAssertEqual("AT&amp;T".safeIdentifier(), "att")
+        XCTAssertEqual("Header\"><script>alert(1)</script>".safeIdentifier(), "header")
+        XCTAssertEqual("<img src=x onerror=alert(1)>".safeIdentifier(), "")
+    }
+
 }


### PR DESCRIPTION
We were failing to strip HTML when auto-generating header anchors/identifiers resulting in invalid HTML.