### PR TITLE
ci: 📦 Only update downstream repositories on a successful release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -290,6 +290,7 @@ jobs:
   macos-update-sparkle:
     needs: publish-release
     if: ${{ needs.publish-release.outputs.released == 'true' }}
+
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -205,20 +205,6 @@ jobs:
         path: build/*
         if-no-files-found: error
 
-  update-releases:
-    needs: publish-release
-    if: ${{ github.ref == 'refs/heads/main' }}
-
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Update releases repository
-      uses: peter-evans/repository-dispatch@v4
-      with:
-        token: ${{ secrets._GITHUB_ACCESS_TOKEN }}
-        repository: inseven/releases
-        event-type: build
-
   website-build:
     needs: macos-build
     runs-on: macos-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -157,6 +157,9 @@ jobs:
     - macos-build
     - linux-build
 
+    outputs:
+      released: ${{ steps.publish.outputs.released }}
+
     env:
       VERSION_NUMBER: ${{ needs.generate-version-number.outputs.version_number }}
       BUILD_NUMBER: ${{ needs.generate-version-number.outputs.build_number }}
@@ -188,6 +191,7 @@ jobs:
         path: artifacts
 
     - name: Publish release
+      id: publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE: ${{ github.ref == 'refs/heads/main' }}
@@ -271,7 +275,7 @@ jobs:
 
   macos-update-homebrew:
     needs: publish-release
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ needs.publish-release.outputs.released == 'true' }}
 
     runs-on: ubuntu-latest
     steps:
@@ -285,7 +289,7 @@ jobs:
 
   macos-update-sparkle:
     needs: publish-release
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ needs.publish-release.outputs.released == 'true' }}
     runs-on: ubuntu-latest
     steps:
 
@@ -294,4 +298,18 @@ jobs:
       with:
         token: ${{ secrets._GITHUB_ACCESS_TOKEN }}
         repository: inseven/sparkle-archives
+        event-type: build
+
+  update-releases:
+    needs: publish-release
+    if: ${{ needs.publish-release.outputs.released == 'true' }}
+
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Update releases repository
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ secrets._GITHUB_ACCESS_TOKEN }}
+        repository: inseven/releases
         event-type: build

--- a/scripts/gh-release.sh
+++ b/scripts/gh-release.sh
@@ -36,3 +36,8 @@ for attachment in "$@"
 do
     gh release upload "$CHANGES_TAG" "$attachment"
 done
+
+# Signal to the CI job that a release was successfully created.
+if [ -n "${GITHUB_OUTPUT:-}" ] ; then
+    echo "released=true" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
This change ensures that the Sparkle archives, Homebrew, and the apt repository, are only updated on a successful release.