### PR TITLE
refactor: Move `CompassDirection` into a top-level enum

### DIFF
--- a/Sources/InContextCore/Importers/CompassDirection.swift
+++ b/Sources/InContextCore/Importers/CompassDirection.swift
@@ -1,0 +1,41 @@
+// MIT License
+//
+// Copyright (c) 2016-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+enum CompassDirection: String {
+
+    case north = "N"
+    case south = "S"
+    case east = "E"
+    case west = "W"
+
+    var multiplier: Double {
+        switch self {
+        case .north, .east:
+            return 1
+        case .south, .west:
+            return -1
+        }
+    }
+
+}

--- a/Sources/InContextCore/Utilities/EXIF.swift
+++ b/Sources/InContextCore/Utilities/EXIF.swift
@@ -42,22 +42,6 @@ import ImageIO
 
 struct EXIF {
 
-    enum CompassDirection: String {
-        case north = "N"
-        case south = "S"
-        case east = "E"
-        case west = "W"
-
-        var multiplier: Double {
-            switch self {
-            case .north, .east:
-                return 1
-            case .west, .south:
-                return -1
-            }
-        }
-    }
-
     private static let dateTimeForatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale.posix


### PR DESCRIPTION
Preparatory work to make it easier to share between different implementations.