### PR TITLE
test: Add tests for the new `PlatformImage` protocol implementations

### DIFF
--- a/Sources/InContextCore/Importers/CoreGraphicsImage.swift
+++ b/Sources/InContextCore/Importers/CoreGraphicsImage.swift
@@ -27,7 +27,7 @@ import ImageIO
 
 import PlatformSupport
 
-final class CoreGraphicsPlatformImage: PlatformImage {
+final class CoreGraphicsImage: PlatformImage {
 
     let source: CGImageSource
 

--- a/Sources/InContextCore/Importers/ImageImporter.swift
+++ b/Sources/InContextCore/Importers/ImageImporter.swift
@@ -25,7 +25,7 @@ import Foundation
 import PlatformSupport
 
 #if canImport(ImageIO)
-let defaultPlatformImage: any PlatformImage.Type = CoreGraphicsPlatformImage.self
+let defaultPlatformImage: any PlatformImage.Type = CoreGraphicsImage.self
 #else
 let defaultPlatformImage: any PlatformImage.Type = DummyPlatformImage.self
 #endif

--- a/Tests/InContextTests/Tests/CoreGraphicsImageTests.swift
+++ b/Tests/InContextTests/Tests/CoreGraphicsImageTests.swift
@@ -27,7 +27,7 @@ import XCTest
 
 #if canImport(ImageIO)
 
-class CoreGraphicsImporterTests: ImageImporterTestCase {
+class CoreGraphicsImageTests: PlatformImageTestCase {
 
     override var imageBackend: any PlatformImage.Type {
         return CoreGraphicsImage.self

--- a/Tests/InContextTests/Tests/PlatformImageTestCase.swift
+++ b/Tests/InContextTests/Tests/PlatformImageTestCase.swift
@@ -1,0 +1,96 @@
+// MIT License
+//
+// Copyright (c) 2016-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import InContextCore
+import PlatformSupport
+
+class PlatformImageTestCase: ContentTestCase {
+
+    var imageBackend: any PlatformImage.Type {
+        fatalError("Subclasses must override `imageBackend`.")
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(type(of: self) == PlatformImageTestCase.self,
+                     "PlatformImageTestCase is abstract; run its subclasses instead.")
+    }
+
+    func testPixelDimensions() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
+        let image = try imageBackend.init(url: url)
+        XCTAssertEqual(try XCTUnwrap(image.pixelWidth), 4032)
+        XCTAssertEqual(try XCTUnwrap(image.pixelHeight), 3024)
+    }
+
+    func testDateTimeOriginal() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
+        let image = try imageBackend.init(url: url)
+        XCTAssertEqual(try image.dateTimeOriginal, Date(2023, 04, 12, 11, 08, 27))
+    }
+
+    func testLocation() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
+        let image = try imageBackend.init(url: url)
+        let latitude = try XCTUnwrap(image.signedLatitude)
+        let longitude = try XCTUnwrap(image.signedLongitude)
+        XCTAssertEqual(latitude, 64.142272166666672, accuracy: 0.0001)
+        XCTAssertEqual(longitude, -21.927391666666665, accuracy: 0.0001)
+    }
+
+    func testImageDescription() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
+        let image = try imageBackend.init(url: url)
+        let description = try XCTUnwrap(image.imageDescription)
+        XCTAssert(description.contains("Hallgrímskirkja Church"))
+    }
+
+    func testFrameCountForStillImage() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
+        let image = try imageBackend.init(url: url)
+        XCTAssertEqual(image.frameCount, 1)
+    }
+
+    func testFrameCountForAnimatedGif() throws {
+        let url = try bundle.throwingURL(forResource: "nezumi_anim", withExtension: "gif")
+        let image = try imageBackend.init(url: url)
+        XCTAssertEqual(image.frameCount, 14)
+    }
+
+    func testResizesImage() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
+        let image = try imageBackend.init(url: url)
+
+        let destinationURL = directoryURL.appendingPathComponent("thumbnail.jpeg")
+        try image.write(maxPixelSize: 400, format: .jpeg, to: destinationURL)
+        XCTAssert(FileManager.default.fileExists(at: destinationURL))
+
+        let thumbnail = try imageBackend.init(url: destinationURL)
+        let width = try XCTUnwrap(thumbnail.pixelWidth)
+        let height = try XCTUnwrap(thumbnail.pixelHeight)
+        XCTAssertEqual(max(width, height), 400)
+    }
+
+}


### PR DESCRIPTION
This change also drive-by renames `CoreGraphicsPlatformImage` to simply `CoreGraphicsImage`.