### PR TITLE
ci: Don’t clean macOS builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -114,7 +114,7 @@ xcodebuild \
     OTHER_CODE_SIGN_FLAGS="--keychain=\"${KEYCHAIN_PATH}\"" \
     MARKETING_VERSION=$VERSION_NUMBER \
     CURRENT_PROJECT_VERSION=$BUILD_NUMBER \
-    clean archive
+    archive
 
 # Build and archive the helper.
 xcodebuild \
@@ -123,7 +123,7 @@ xcodebuild \
     -archivePath "$HELPER_ARCHIVE_PATH" \
     MARKETING_VERSION=$VERSION_NUMBER \
     CURRENT_PROJECT_VERSION=$BUILD_NUMBER \
-    clean archive
+    archive
 
 popd
 


### PR DESCRIPTION
I feel a bit uneasy about this one—it relies on Xcode not corrupting DerivedData, which we know it does—but right now the build times are significantly gating small bug fixes and feature work. We can back this out if we find it leads to failing builds.