### PR TITLE
ci: Cache Linux build intermediates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,6 +140,14 @@ jobs:
         submodules: recursive
         lfs: true
 
+    - name: Cache Swift build directory
+      uses: actions/cache@v4
+      with:
+        path: .build
+        key: swift-build-${{ matrix.name }}-${{ hashFiles('Package.resolved') }}
+        restore-keys: |
+          swift-build-${{ matrix.name }}-
+
     - name: Install dependencies
       run: scripts/install-linux-dependencies.sh
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -35,10 +35,6 @@ BUILD_DIRECTORY="$ROOT_DIRECTORY/build"
 SWIFT_BUILD_DIRECTORY="$ROOT_DIRECTORY/.build"
 ARTIFACTS_DIRECTORY="$BUILD_DIRECTORY/artifacts"
 
-# Clean up and recreate the output directories.
-if [ -d "$SWIFT_BUILD_DIRECTORY" ] ; then
-    rm -rf "$SWIFT_BUILD_DIRECTORY"
-fi
 if [ -d "$BUILD_DIRECTORY" ] ; then
     rm -r "$BUILD_DIRECTORY"
 fi


### PR DESCRIPTION
Since we now have significant dependencies, it makes sense to try caching the intermediates between Linux builds.