### PR TITLE
ci: Use Ubuntu 26.04 runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,15 +107,15 @@ jobs:
           os: ubuntu-26.04
           # container: ubuntu:resolute
           setup: |
-            apt-get update -y
-            apt-get install -y build-essential git git-lfs swiftlang
+            sudo apt-get update -y
+            sudo apt-get install -y build-essential git git-lfs swiftlang
 
         - name: ubuntu-resolute-arm64
           os: ubuntu-26.04-arm
           # container: ubuntu:resolute
           setup: |
-            apt-get update -y
-            apt-get install -y build-essential git git-lfs swiftlang
+            sudo apt-get update -y
+            sudo apt-get install -y build-essential git git-lfs swiftlang
 
     name: ${{ matrix.name }}-build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,17 +105,9 @@ jobs:
 
         - name: ubuntu-resolute-amd64
           os: ubuntu-26.04
-          # container: ubuntu:resolute
-          setup: |
-            sudo apt-get update -y
-            sudo apt-get install -y build-essential git git-lfs swiftlang
 
         - name: ubuntu-resolute-arm64
           os: ubuntu-26.04-arm
-          # container: ubuntu:resolute
-          setup: |
-            sudo apt-get update -y
-            sudo apt-get install -y build-essential git git-lfs swiftlang
 
     name: ${{ matrix.name }}-build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,15 +104,15 @@ jobs:
         include:
 
         - name: ubuntu-resolute-amd64
-          os: ubuntu-24.04
-          container: ubuntu:resolute
+          os: ubuntu-26.04
+          # container: ubuntu:resolute
           setup: |
             apt-get update -y
             apt-get install -y build-essential git git-lfs swiftlang
 
         - name: ubuntu-resolute-arm64
-          os: ubuntu-24.04-arm
-          container: ubuntu:resolute
+          os: ubuntu-26.04-arm
+          # container: ubuntu:resolute
           setup: |
             apt-get update -y
             apt-get install -y build-essential git git-lfs swiftlang

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,9 +105,15 @@ jobs:
 
         - name: ubuntu-resolute-amd64
           os: ubuntu-26.04
+          setup: |
+            sudo apt-get update -y
+            sudo apt-get install -y swiftlang
 
         - name: ubuntu-resolute-arm64
           os: ubuntu-26.04-arm
+          setup: |
+            sudo apt-get update -y
+            sudo apt-get install -y swiftlang
 
     name: ${{ matrix.name }}-build
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This change switches to using the new `ubuntu-26.04` and `ubuntu-26.04-arm` runners to avoid the additional overhead of building inside a container.