### PR TITLE
fix: 🏞️ Respect Frontmatter dates in image descriptions

### DIFF
--- a/Sources/InContextCore/Importers/ImageImporter.swift
+++ b/Sources/InContextCore/Importers/ImageImporter.swift
@@ -296,7 +296,7 @@ extension ImageImporter: Importer {
 
         // N.B. The EXIF 'DateTimeOriginal' field sometimes appears to be invalid so we fall back on DateTimeDigitized.
 
-        let date = try (try? image.dateTimeOriginal) ?? (try image.dateTimeDigitized) ?? details.date
+        let date = try (try? image.dateTimeOriginal) ?? (try image.dateTimeDigitized) ?? content?.date ?? details.date
         let title = try image.firstTitle ?? content?.title ?? filenameTitle
 
         let document = try Document(url: fileURL.siteURL,

--- a/Sources/InContextCore/Importers/VideoImporter.swift
+++ b/Sources/InContextCore/Importers/VideoImporter.swift
@@ -66,24 +66,24 @@ class VideoImporter: Importer {
 
         // Load the video.
         let asset = AVAsset(url: file.url)
+        let quickTimeMetadata = try await asset.loadMetadata(for: .quickTimeMetadata)
 
-        // Load the details from the filename.
-        let details = fileURL.basenameDetails()
-
-        // Get the first track to guess the dimensions.
+        // Get the size by inspecting the first track.
         let videoTracks = try await asset.load(.tracks).filter { track in
             return track.mediaType == .video
         }
-
         guard let naturalSize = try await videoTracks.first?.load(.naturalSize) else {
             throw InContextError.videoLibraryError("Failed to determine size of video '\(fileURL.relativePath)'.")
         }
         let size = Size(naturalSize)
 
-        let quickTimeMetadata = try await asset.loadMetadata(for: .quickTimeMetadata)
+        // Load the details from the filename.
+        let details = fileURL.basenameDetails()
+
+        // Metadata.
+        var metadata: [String: Any] = [:]
 
         // Get the metadata title and description.
-        let metadataTitle = try await quickTimeMetadata.quickTimeMetadataTitle
         let content: FrontmatterDocument? = if let description = try await quickTimeMetadata.quickTimeMetadataDescription {
             try FrontmatterDocument(contents: description, generateHTML: true)
         } else {
@@ -101,29 +101,23 @@ class VideoImporter: Importer {
         let thumbnailURL = assetsURL.appendingPathComponent("thumbnail", conformingTo: .jpeg)
         try await thumbnail(asset: asset, destinationURL: thumbnailURL)
 
-        let thumbnailDetails: [String: Any] = [
-            "url": thumbnailURL.relativePath.ensuringLeadingSlash(),
-            "width": size.width,
-            "height": size.height,
-            "filename": "cheese",
-        ]
-
-        let videoDetails: [String: Any] = [
+        metadata["video"] = [
             "url": videoURL.relativePath.ensuringLeadingSlash(),
             "width": size.width,
             "height": size.height,
             "filename": "cheese",
         ]
 
-        let metadata: [String: Any] = [
-            "thumbnail": thumbnailDetails,
-            "video": videoDetails,
+        metadata["thumbnail"] = [
+            "url": thumbnailURL.relativePath.ensuringLeadingSlash(),
+            "width": size.width,
+            "height": size.height,
+            "filename": "cheese",
         ]
 
         let filenameTitle = settings.titleFromFilename ? details.title : nil
-        let title = metadataTitle ?? content?.title ?? filenameTitle
-        let videoCreationDate = try await quickTimeMetadata.creationDate
-        let date = content?.date ?? videoCreationDate ?? details.date
+        let title = (try await quickTimeMetadata.quickTimeMetadataTitle) ?? content?.title ?? filenameTitle
+        let date = (try await quickTimeMetadata.creationDate) ?? content?.date ?? details.date
 
         let document = try Document(url: fileURL.siteURL,
                                     parent: fileURL.parentURL,


### PR DESCRIPTION
This change also includes a drive-by refactor to try to make the video metadata derivation clearer and bring it closer to the `ImageImporter` approach.