### PR TITLE
fix: 📋 Prefer Frontmatter dates and titles over media metadata

### DIFF
--- a/Sources/InContextCore/Importers/ImageImporter.swift
+++ b/Sources/InContextCore/Importers/ImageImporter.swift
@@ -215,7 +215,7 @@ class ImageImporter {
     }
 
     let identifier = "image"
-    let version = 13
+    let version = 14
 
     func settings(for configuration: [String : Any]) throws -> Settings {
         return Settings(defaultCategory: try configuration.requiredValue(for: "category"),
@@ -292,12 +292,14 @@ extension ImageImporter: Importer {
             break
         }
 
+        // TItle.
+        let metadataTitle = try image.firstTitle
         let filenameTitle = settings.titleFromFilename ? details.title : nil
+        let title = content?.title ?? metadataTitle ?? filenameTitle
 
-        // N.B. The EXIF 'DateTimeOriginal' field sometimes appears to be invalid so we fall back on DateTimeDigitized.
-
-        let date = try (try? image.dateTimeOriginal) ?? (try image.dateTimeDigitized) ?? content?.date ?? details.date
-        let title = try image.firstTitle ?? content?.title ?? filenameTitle
+        // Date.
+        let metadataDate = try image.dateTimeOriginal ?? image.dateTimeDigitized
+        let date = content?.date ?? metadataDate ?? details.date
 
         let document = try Document(url: fileURL.siteURL,
                                     parent: fileURL.parentURL,

--- a/Sources/InContextCore/Importers/VideoImporter.swift
+++ b/Sources/InContextCore/Importers/VideoImporter.swift
@@ -43,7 +43,7 @@ class VideoImporter: Importer {
     }
 
     let identifier = "video"
-    let version = 8
+    let version = 9
 
     func settings(for configuration: [String : Any]) throws -> Settings {
         return Settings(defaultCategory: try configuration.requiredValue(for: "category"),
@@ -115,14 +115,19 @@ class VideoImporter: Importer {
             "filename": "cheese",
         ]
 
+        // Title.
+        let metadataTitle = try await quickTimeMetadata.quickTimeMetadataTitle
         let filenameTitle = settings.titleFromFilename ? details.title : nil
-        let title = (try await quickTimeMetadata.quickTimeMetadataTitle) ?? content?.title ?? filenameTitle
-        let date = (try await quickTimeMetadata.creationDate) ?? content?.date ?? details.date
+        let title = content?.title ?? metadataTitle ?? filenameTitle
+
+        // Date.
+        let metadataDate = try await quickTimeMetadata.creationDate
+        let date = content?.date ?? metadataDate ?? details.date
 
         let document = try Document(url: fileURL.siteURL,
                                     parent: fileURL.parentURL,
                                     category: settings.defaultCategory,
-                                    date: content?.date ?? date,
+                                    date: date,
                                     title: title,
                                     metadata: metadata,
                                     contents: content?.content ?? "",


### PR DESCRIPTION
This change prioritizes metadata from Frontmatter in media descriptions to the metadata priorities on the media; we assume the user has consciously overridden these to provide updated values.