### PR TITLE
fix: 📼 Resize videos and thumbnails

### DIFF
--- a/Sources/InContextCore/Importers/AVFoundationVideo.swift
+++ b/Sources/InContextCore/Importers/AVFoundationVideo.swift
@@ -1,0 +1,160 @@
+// MIT License
+//
+// Copyright (c) 2016-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if canImport(AVFoundation)
+
+import AVFoundation
+import CoreImage
+import Foundation
+import ImageIO
+
+import PlatformSupport
+
+final class AVFoundationVideo: PlatformVideo {
+
+    private let asset: AVAsset
+    private let quickTimeMetadata: [AVMetadataItem]
+
+    init(url: URL) async throws {
+        self.asset = AVAsset(url: url)
+        self.quickTimeMetadata = try await asset.loadMetadata(for: .quickTimeMetadata)
+    }
+
+    private var videoTrack: AVAssetTrack? {
+        get async throws {
+            try await asset.load(.tracks).first { $0.mediaType == .video }
+        }
+    }
+
+    var size: Size? {
+        get async throws {
+            guard let naturalSize = try await videoTrack?.load(.naturalSize) else {
+                return nil
+            }
+            return Size(naturalSize)
+        }
+    }
+
+    var duration: Double? {
+        get async throws {
+            let duration = try await asset.load(.duration)
+            guard duration.isNumeric else {
+                return nil
+            }
+            return duration.seconds
+        }
+    }
+
+    var creationDate: Date? {
+        get async throws {
+            return try await quickTimeMetadata.creationDate
+        }
+    }
+
+    var title: String? {
+        get async throws {
+            try await quickTimeMetadata.title
+        }
+    }
+
+    var mediaDescription: String? {
+        get async throws {
+            try await quickTimeMetadata.description
+        }
+    }
+
+    var location: (latitude: Double, longitude: Double)? {
+        get async throws {
+            try await quickTimeMetadata.location
+        }
+    }
+
+    func writeThumbnail(at time: Double, maxPixelSize: Int, format: UTType, to url: URL) async throws {
+        guard let videoSize = try await size else {
+            throw InContextError.videoLibraryError("Failed to determine video dimensions.")
+        }
+        let size = videoSize.fit(width: maxPixelSize)
+
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: size.width, height: size.height)
+        let result = try await generator.image(at: CMTime(seconds: time, preferredTimescale: 600))
+
+        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, format.identifier as CFString, 1, nil) else {
+            throw InContextError.videoLibraryError("Failed to create thumbnail destination at '\(url.relativePath)'.")
+        }
+        CGImageDestinationAddImage(destination, result.image, nil)
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw InContextError.videoLibraryError("Failed to write thumbnail to '\(url.relativePath)'.")
+        }
+    }
+
+    func writeVideo(maxPixelSize: Int, format: UTType, to url: URL) async throws {
+        guard format == .mov else {
+            throw InContextError.unsupportedMediaType
+        }
+
+        guard let videoSize = try await size else {
+            throw InContextError.videoLibraryError("Failed to determine video dimensions.")
+        }
+        let size = videoSize.fit(width: maxPixelSize)
+        let scale = Double(size.width) / Double(videoSize.width)
+
+        let composition = AVMutableVideoComposition(asset: asset) { request in
+            let filter = CIFilter(name: "CILanczosScaleTransform")
+            filter?.setValue(request.sourceImage, forKey: kCIInputImageKey)
+            filter?.setValue(scale, forKey: kCIInputScaleKey)
+            filter?.setValue(1.0, forKey: kCIInputAspectRatioKey)
+            request.finish(with: filter?.outputImage ?? request.sourceImage, context: nil)
+        }
+        composition.renderSize = CGSize(size)
+
+        let preset = Self.exportPreset(forLongestEdge: max(size.width, size.height))
+        guard await AVAssetExportSession.compatibility(ofExportPreset: preset, with: asset, outputFileType: .mov) else {
+            throw InContextError.videoLibraryError("Preset '\(preset)' is not compatible with this asset.")
+        }
+
+        guard let exportSession = AVAssetExportSession(asset: asset, presetName: preset) else {
+            throw InContextError.videoLibraryError("Failed to create export session.")
+        }
+        exportSession.videoComposition = composition
+
+        try await exportSession.export(to: url, as: .mov)
+    }
+
+    private static func exportPreset(forLongestEdge longestEdge: Int) -> String {
+        switch longestEdge {
+        case ..<640:
+            return AVAssetExportPreset640x480
+        case ..<960:
+            return AVAssetExportPreset960x540
+        case ..<1280:
+            return AVAssetExportPreset1280x720
+        default:
+            return AVAssetExportPreset1920x1080
+        }
+    }
+
+}
+
+#endif

--- a/Sources/InContextCore/Importers/DummyPlatformVideo.swift
+++ b/Sources/InContextCore/Importers/DummyPlatformVideo.swift
@@ -22,34 +22,44 @@
 
 import Foundation
 
-struct Size {
-    let width: Int
-    let height: Int
+import PlatformSupport
 
-    init(width: Int, height: Int) {
-        self.width = width
-        self.height = height
+final class DummyPlatformVideo: PlatformVideo {
+
+    init(url: URL) async throws {
+        throw InContextError.unsupportedMediaType
     }
 
-    init(_ size: CGSize) {
-        self.width = Int(size.width)
-        self.height = Int(size.height)
+    var size: Size? {
+        get async throws { fatalError("Unsupported media type.") }
     }
 
-    func fit(width: Int) -> Size {
-        if self.width <= width {
-            return self
-        }
-        let ratio = Double(self.width) / Double(self.height)
-        let height = Double(width) / ratio
-        return Size(width: width, height: Int(height))
+    var duration: Double? {
+        get async throws { fatalError("Unsupported media type.") }
     }
-}
 
-extension CGSize {
+    var creationDate: Date? {
+        get async throws { fatalError("Unsupported media type.") }
+    }
 
-    init(_ size: Size) {
-        self.init(width: size.width, height: size.height)
+    var title: String? {
+        get async throws { fatalError("Unsupported media type.") }
+    }
+
+    var mediaDescription: String? {
+        get async throws { fatalError("Unsupported media type.") }
+    }
+
+    var location: (latitude: Double, longitude: Double)? {
+        get async throws { fatalError("Unsupported media type.") }
+    }
+
+    func writeThumbnail(at time: Double, maxPixelSize: Int, format: UTType, to url: URL) async throws {
+        fatalError("Unsupported media type.")
+    }
+
+    func writeVideo(maxPixelSize: Int, format: UTType, to url: URL) async throws {
+        fatalError("Unsupported media type.")
     }
 
 }

--- a/Sources/InContextCore/Importers/PlatformVideo.swift
+++ b/Sources/InContextCore/Importers/PlatformVideo.swift
@@ -22,34 +22,20 @@
 
 import Foundation
 
-struct Size {
-    let width: Int
-    let height: Int
+import PlatformSupport
 
-    init(width: Int, height: Int) {
-        self.width = width
-        self.height = height
-    }
+protocol PlatformVideo {
 
-    init(_ size: CGSize) {
-        self.width = Int(size.width)
-        self.height = Int(size.height)
-    }
+    init(url: URL) async throws
 
-    func fit(width: Int) -> Size {
-        if self.width <= width {
-            return self
-        }
-        let ratio = Double(self.width) / Double(self.height)
-        let height = Double(width) / ratio
-        return Size(width: width, height: Int(height))
-    }
-}
+    var size: Size? { get async throws }
+    var duration: Double? { get async throws }
+    var creationDate: Date? { get async throws }
+    var title: String? { get async throws }
+    var mediaDescription: String? { get async throws }
+    var location: (latitude: Double, longitude: Double)? { get async throws }
 
-extension CGSize {
-
-    init(_ size: Size) {
-        self.init(width: size.width, height: size.height)
-    }
+    func writeThumbnail(at time: Double, maxPixelSize: Int, format: UTType, to url: URL) async throws
+    func writeVideo(maxPixelSize: Int, format: UTType, to url: URL) async throws
 
 }

--- a/Sources/InContextCore/Importers/VideoImporter.swift
+++ b/Sources/InContextCore/Importers/VideoImporter.swift
@@ -22,8 +22,12 @@
 
 import Foundation
 
+import PlatformSupport
+
 #if canImport(AVFoundation)
-import AVFoundation
+typealias NativeVideo = AVFoundationVideo
+#else
+typealias NativeVideo = DummyPlatformVideo
 #endif
 
 class VideoImporter: Importer {
@@ -42,6 +46,10 @@ class VideoImporter: Importer {
         }
     }
 
+    static let videoSize: Int = 1920
+    static let thumbnailSize: Int = 400
+    static let thumbnailOffset: Double = 1
+
     let identifier = "video"
     let version = 9
 
@@ -51,8 +59,6 @@ class VideoImporter: Importer {
                         defaultTemplate: try configuration.requiredValue(for: "defaultTemplate"),
                         inlineTemplate: try configuration.requiredValue(for: "inlineTemplate"))
     }
-
-#if canImport(AVFoundation)
 
     static func process(file: File,
                         settings: Settings,
@@ -65,17 +71,12 @@ class VideoImporter: Importer {
         try FileManager.default.createDirectory(at: assetsURL, withIntermediateDirectories: true)
 
         // Load the video.
-        let asset = AVAsset(url: file.url)
-        let quickTimeMetadata = try await asset.loadMetadata(for: .quickTimeMetadata)
+        let video = try await NativeVideo(url: fileURL)
 
-        // Get the size by inspecting the first track.
-        let videoTracks = try await asset.load(.tracks).filter { track in
-            return track.mediaType == .video
-        }
-        guard let naturalSize = try await videoTracks.first?.load(.naturalSize) else {
+        // Get the size.
+        guard let size = try await video.size else {
             throw InContextError.videoLibraryError("Failed to determine size of video '\(fileURL.relativePath)'.")
         }
-        let size = Size(naturalSize)
 
         // Load the details from the filename.
         let details = fileURL.basenameDetails()
@@ -89,14 +90,12 @@ class VideoImporter: Importer {
         }
 
         // Duration.
-        let duration = try await asset.load(.duration)
-        if duration.isNumeric {
-            metadata["duration"] = duration.seconds
-
+        if let duration = try await video.duration {
+            metadata["duration"] = duration
         }
 
         // Location.
-        if let location = try await quickTimeMetadata.location {
+        if let location = try await video.location {
             metadata["location"] = [
                 "latitude": location.latitude,
                 "longitude": location.longitude,
@@ -105,47 +104,50 @@ class VideoImporter: Importer {
 
         // Content.
         var content: FrontmatterDocument? = nil
-        if let videoDescription = try await quickTimeMetadata.description {
-            let frontmatter = try FrontmatterDocument(contents: videoDescription, generateHTML: true)
+        if let mediaDescription = try await video.mediaDescription {
+            let frontmatter = try FrontmatterDocument(contents: mediaDescription, generateHTML: true)
             guard let contentMetadata = frontmatter.metadata as? [String: Any] else {
-                throw InContextError.internalInconsistency("Unexpected metadata type")
+                throw InContextError.internalInconsistency("Unexpected key type for metadata")
             }
             metadata.merge(contentMetadata) { $1 }
             content = frontmatter
         }
 
-        // TODO: Scale video.
-        let videoURL = assetsURL.appendingPathComponent("video.mov")
-        try await export(video: asset,
-                         withPreset: AVAssetExportPresetHighestQuality,
-                         toFileType: .mov,
-                         atURL: videoURL)
+        // Convert the video.
+        let videoFormat: UTType = .mov
+        let videoSize = size.fit(width: Self.videoSize)
+        let videoFilename = "video." + (videoFormat.preferredFilenameExtension ?? "mov")
+        let videoURL = assetsURL.appendingPathComponent(videoFilename)
+        try await video.writeVideo(maxPixelSize: Self.videoSize, format: videoFormat, to: videoURL)
 
-        // TODO: Scale thumbnail.
-        let thumbnailURL = assetsURL.appendingPathComponent("thumbnail", conformingTo: .jpeg)
-        try await thumbnail(asset: asset, destinationURL: thumbnailURL)
+        // Generate the thumbnail.
+        let thumbnailSize = size.fit(width: Self.thumbnailSize)
+        let thumbnailFilename = "thumbnail." + (UTType.jpeg.preferredFilenameExtension ?? "jpg")
+        let thumbnailURL = assetsURL.appendingPathComponent(thumbnailFilename)
+        try await video.writeThumbnail(at: Self.thumbnailOffset,
+                                       maxPixelSize: Self.thumbnailSize,
+                                       format: .jpeg,
+                                       to: thumbnailURL)
 
         metadata["video"] = [
             "url": videoURL.relativePath.ensuringLeadingSlash(),
-            "width": size.width,
-            "height": size.height,
-            "filename": "cheese",
-        ]
+            "width": videoSize.width,
+            "height": videoSize.height,
+        ] as [String: Any]
 
         metadata["thumbnail"] = [
             "url": thumbnailURL.relativePath.ensuringLeadingSlash(),
-            "width": size.width,
-            "height": size.height,
-            "filename": "cheese",
-        ]
+            "width": thumbnailSize.width,
+            "height": thumbnailSize.height,
+        ] as [String: Any]
 
         // Title.
-        let metadataTitle = try await quickTimeMetadata.title
+        let metadataTitle = try await video.title
         let filenameTitle = settings.titleFromFilename ? details.title : nil
         let title = content?.title ?? metadataTitle ?? filenameTitle
 
         // Date.
-        let metadataDate = try await quickTimeMetadata.creationDate
+        let metadataDate = try await video.creationDate
         let date = content?.date ?? metadataDate ?? details.date
 
         let document = try Document(url: fileURL.siteURL,
@@ -163,58 +165,5 @@ class VideoImporter: Importer {
 
         return ImporterResult(document: document, assets: [Asset(fileURL: videoURL), Asset(fileURL: thumbnailURL)])
     }
-
-    static func thumbnail(asset: AVAsset, destinationURL: URL) async throws {
-        let generator = AVAssetImageGenerator(asset: asset)
-        generator.appliesPreferredTrackTransform = true
-        let time = CMTime(seconds: 1, preferredTimescale: 1)
-        let result = try await generator.image(at: time)
-
-        let format: UTType = .jpeg
-
-        guard let destination = CGImageDestinationCreateWithURL(destinationURL as CFURL,
-                                                                format.identifier as CFString,
-                                                                1,
-                                                                nil) else {
-            throw InContextError.videoLibraryError("Failed to save thumbnail at '\(destinationURL.relativePath)'.")
-        }
-        CGImageDestinationAddImage(destination, result.image, nil)
-        CGImageDestinationFinalize(destination)  // TODO: Handle error here?
-
-    }
-
-    // https://developer.apple.com/documentation/avfoundation/media_reading_and_writing/exporting_video_to_alternative_formats
-    static func export(video: AVAsset,
-                       withPreset preset: String = AVAssetExportPresetHighestQuality,
-                       toFileType outputFileType: AVFileType = .mov,
-                       atURL outputURL: URL) async throws {
-
-        // Check the compatibility of the preset to export the video to the output file type.
-        guard await AVAssetExportSession.compatibility(ofExportPreset: preset,
-                                                       with: video,
-                                                       outputFileType: outputFileType) else {
-            throw InContextError.videoLibraryError("The preset can't export the video to the output file type.")
-        }
-
-        // Create and configure the export session.
-        guard let exportSession = AVAssetExportSession(asset: video,
-                                                       presetName: preset) else {
-            throw InContextError.videoLibraryError("Failed to create export session.")
-        }
-
-        // Convert the video to the output file type and export it to the output URL.
-        try await exportSession.export(to: outputURL, as: outputFileType)
-    }
-
-#else
-
-    static func process(file: File,
-                        settings: Settings,
-                        outputURL: URL) async throws -> ImporterResult {
-
-        throw InContextError.internalInconsistency("Unsupported")
-    }
-
-#endif
 
 }

--- a/Sources/InContextCore/Importers/VideoImporter.swift
+++ b/Sources/InContextCore/Importers/VideoImporter.swift
@@ -51,7 +51,7 @@ class VideoImporter: Importer {
     static let thumbnailOffset: Double = 1
 
     let identifier = "video"
-    let version = 9
+    let version = 10
 
     func settings(for configuration: [String : Any]) throws -> Settings {
         return Settings(defaultCategory: try configuration.requiredValue(for: "category"),

--- a/Tests/InContextTests/Tests/PlatformVideoTests.swift
+++ b/Tests/InContextTests/Tests/PlatformVideoTests.swift
@@ -1,0 +1,106 @@
+// MIT License
+//
+// Copyright (c) 2016-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import InContextCore
+
+// TODO: Remove this guard once NativeVideo is switched back to GStreamerVideo on Linux (see
+// VideoImporter.swift).
+#if canImport(AVFoundation)
+
+class PlatformVideoTests: ContentTestCase {
+
+    func testPixelDimensions() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+        let size = try await video.size
+        let unwrapped = try XCTUnwrap(size)
+        XCTAssertEqual(unwrapped.width, 1920)
+        XCTAssertEqual(unwrapped.height, 1080)
+    }
+
+    func testDuration() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+        let duration = try await video.duration
+        XCTAssertEqual(try XCTUnwrap(duration), 7.835, accuracy: 0.01)
+    }
+
+    func testCreationDate() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+        let creationDate = try await video.creationDate
+        XCTAssertEqual(try XCTUnwrap(creationDate), Date(2022, 05, 31, 17, 55, 03, timeZone: TimeZone(1)!))
+    }
+
+    func testMediaDescription() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+        let mediaDescription = try await video.mediaDescription
+        let description = try XCTUnwrap(mediaDescription)
+        XCTAssert(description.contains("Royal Wave"))
+        XCTAssert(description.contains("Platinum Jubilee"))
+    }
+
+    func testLocation() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+        let location = try await video.location
+        let coordinate = try XCTUnwrap(location)
+        XCTAssertEqual(coordinate.latitude, 51.5126, accuracy: 0.0001)
+        XCTAssertEqual(coordinate.longitude, -0.1240, accuracy: 0.0001)
+    }
+
+    func testWritesThumbnail() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+
+        let destinationURL = directoryURL.appendingPathComponent("thumbnail.jpeg")
+        try await video.writeThumbnail(at: 1, maxPixelSize: 400, format: .jpeg, to: destinationURL)
+        XCTAssert(FileManager.default.fileExists(at: destinationURL))
+
+        let thumbnail = try NativeImage(url: destinationURL)
+        let size = try XCTUnwrap(thumbnail.size)
+        // AVAssetImageGenerator.maximumSize is a bounding box, not an exact fit, so the encoder's
+        // even-dimension rounding can land a pixel or two under the requested size.
+        XCTAssertEqual(Double(max(size.width, size.height)), 400, accuracy: 2)
+    }
+
+    func testWritesVideo() async throws {
+        let url = try bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+
+        let destinationURL = directoryURL.appendingPathComponent("video.mov")
+        try await video.writeVideo(maxPixelSize: 640, format: .mov, to: destinationURL)
+        XCTAssert(FileManager.default.fileExists(at: destinationURL))
+
+        let transcoded = try await NativeVideo(url: destinationURL)
+        let transcodedSize = try await transcoded.size
+        let size = try XCTUnwrap(transcodedSize)
+        XCTAssertEqual(max(size.width, size.height), 640)
+    }
+
+}
+
+#endif

--- a/Tests/InContextTests/Tests/VideoImporterTests.swift
+++ b/Tests/InContextTests/Tests/VideoImporterTests.swift
@@ -25,7 +25,7 @@ import Foundation
 import XCTest
 @testable import InContextCore
 
-#if !os(Linux)
+#if canImport(AVFoundation)
 
 class VideoImporterTests: ContentTestCase {
 


### PR DESCRIPTION
This change is a thinly veiled refactor, introducing `PlatformVideo` in preparation for adding Linux video support.