### PR TITLE
test: Enable `IntegrationTests.testAltAndTitlePromotedFromMarkdownImage` on Linux

### DIFF
--- a/Tests/InContextTests/Tests/IntegrationTests.swift
+++ b/Tests/InContextTests/Tests/IntegrationTests.swift
@@ -27,8 +27,6 @@ import XCTest
 
 class IntegrationTests: XCTestCase {
 
-#if !os(Linux)
-
     func testAltAndTitlePromotedFromMarkdownImage() async throws {
         try await withTemporarySourceDirectory { sourceDirectory in
             _ = try sourceDirectory.add("site.yaml", contents: """
@@ -76,8 +74,6 @@ steps:
             XCTAssertTrue(html.contains(#"title="My favourite cat photo""#))
         }
     }
-
-#endif
 
     func testAdmonitionRewritesBlockquote() async throws {
         try await withTemporarySourceDirectory { sourceDirectory in


### PR DESCRIPTION
This slipped through the net when adding Linux image support.