### PR TITLE
fix: 🤳 Support HEIC images on Linux

### DIFF
--- a/Tests/InContextTests/Resources/IMG_0581.heic
+++ b/Tests/InContextTests/Resources/IMG_0581.heic
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36bfd4ec841530d42166c4d66ea7b20f417e332ce5152f0ccd2fb613882710db
+size 834640

--- a/Tests/InContextTests/Tests/PlatformImageTests.swift
+++ b/Tests/InContextTests/Tests/PlatformImageTests.swift
@@ -100,4 +100,31 @@ class PlatformImageTests: ContentTestCase {
         XCTAssertEqual(max(size.width, size.height), 400)
     }
 
+    func testHeicPixelDimensions() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "heic")
+        let image = try NativeImage(url: url)
+        let size = try XCTUnwrap(image.size)
+        XCTAssertEqual(size.width, 4032)
+        XCTAssertEqual(size.height, 3024)
+    }
+
+    func testHeicDateTimeOriginal() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "heic")
+        let image = try NativeImage(url: url)
+        XCTAssertEqual(try image.dateTimeOriginal, Date(2023, 04, 12, 11, 08, 27))
+    }
+
+    func testResizesHeicImage() throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "heic")
+        let image = try NativeImage(url: url)
+
+        let destinationURL = directoryURL.appendingPathComponent("thumbnail.jpeg")
+        try image.write(maxPixelSize: 400, format: .jpeg, to: destinationURL)
+        XCTAssert(FileManager.default.fileExists(at: destinationURL))
+
+        let thumbnail = try NativeImage(url: destinationURL)
+        let size = try XCTUnwrap(thumbnail.size)
+        XCTAssertEqual(max(size.width, size.height), 400)
+    }
+
 }

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -87,6 +87,12 @@ case $DISTRO in
             DEPENDS_ARGS+=(--depends "$package")
         done
 
+        # Manually add dynamically linked dependencies we can't auto-detect.
+
+        # Required for HEIC support.
+        DEPENDS_ARGS+=(--depends libmagickcore-7.q16-10-extra)
+        DEPENDS_ARGS+=(--depends libheif-plugin-libde265)
+
         fpm \
             -s dir \
             -t deb \

--- a/scripts/install-linux-dependencies.sh
+++ b/scripts/install-linux-dependencies.sh
@@ -47,7 +47,8 @@ case $ID in
             ruby ruby-bundler \
             pkg-config \
             libsqlite3-dev \
-            libmagickwand-dev
+            libmagickwand-dev \
+            libheif-plugin-libde265
         $SUDO gem install --no-user-install fpm
         ;;
 


### PR DESCRIPTION
Thankfully this is just a matter—on Ubuntu 26.04 at least—of making sure libheif is available and we depend on it.