### PR TITLE
fix: 🎞️ Increase reliability with multiple concurrent image imports on Linux

### DIFF
--- a/Sources/InContextCore/Importers/CoreGraphicsImage.swift
+++ b/Sources/InContextCore/Importers/CoreGraphicsImage.swift
@@ -34,7 +34,7 @@ final class CoreGraphicsImage: PlatformImage {
     private let properties: [String: Any]
     private let metadata: CGImageMetadata
 
-    init(url: URL) throws {
+    init(url: URL) async throws {
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
             throw InContextError.internalInconsistency("Failed to open image file at '\(url.relativePath)'.")
         }

--- a/Sources/InContextCore/Importers/ImageImporter.swift
+++ b/Sources/InContextCore/Importers/ImageImporter.swift
@@ -231,7 +231,7 @@ class ImageImporter: Importer {
         try FileManager.default.createDirectory(at: assetsURL, withIntermediateDirectories: true)
 
         // Load the image.
-        let image = try NativeImage(url: fileURL)
+        let image = try await NativeImage(url: fileURL)
 
         // Load the details from the filename.
         let details = fileURL.basenameDetails()

--- a/Sources/InContextCore/Importers/MagickImage.swift
+++ b/Sources/InContextCore/Importers/MagickImage.swift
@@ -58,6 +58,13 @@ actor MagicWand {
         isInitialized = true
     }
 
+    deinit {
+        guard isInitialized else {
+            return
+        }
+        MagicWandTerminus()
+    }
+
 }
 
 let magicWand = MagicWand()

--- a/Sources/InContextCore/Importers/MagickImage.swift
+++ b/Sources/InContextCore/Importers/MagickImage.swift
@@ -29,22 +29,14 @@ import CMagickWand
 
 actor MagicWand {
 
-    var isInitialized = false
-
-    init() {
-
-    }
+    private var isInitialized = false
 
     func initialize() throws {
-        try configureResourcePolicy()
-        MagickWandGenesis()
-    }
-
-    private func configureResourcePolicy() throws {
         guard !isInitialized else {
             return
         }
-        isInitialized = true
+
+        // Relax ImageMagick's resource policy.
         let configDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("incontext-imagemagick-policy", isDirectory: true)
         let policyURL = configDirectory.appendingPathComponent("policy.xml")
@@ -59,6 +51,11 @@ actor MagicWand {
         try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
         try policy.write(to: policyURL, atomically: true, encoding: .utf8)
         setenv("MAGICK_CONFIGURE_PATH", configDirectory.path, 1)
+
+        // Initialize MagicWand.
+        MagickWandGenesis()
+
+        isInitialized = true
     }
 
 }
@@ -70,30 +67,6 @@ func initializeMagicWand() async throws {
 }
 
 final class MagickImage: PlatformImage {
-
-    /// Initialize MagickWand.
-    private static let genesis: Void = {
-        MagickImage.configureResourcePolicy()
-        MagickWandGenesis()
-    }()
-
-    // Relax ImageMagick's resource policy.
-    private static func configureResourcePolicy() {
-        let configDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("incontext-imagemagick-policy", isDirectory: true)
-        let policyURL = configDirectory.appendingPathComponent("policy.xml")
-        let policy = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <policymap>
-          <policy domain="resource" name="memory" value="4GiB"/>
-          <policy domain="resource" name="map" value="8GiB"/>
-          <policy domain="resource" name="disk" value="8GiB"/>
-        </policymap>
-        """
-        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
-        try policy.write(to: policyURL, atomically: true, encoding: .utf8)
-        setenv("MAGICK_CONFIGURE_PATH", configDirectory.path, 1)
-    }
 
     private let wand: OpaquePointer
 

--- a/Sources/InContextCore/Importers/MagickImage.swift
+++ b/Sources/InContextCore/Importers/MagickImage.swift
@@ -8,8 +8,27 @@ final class MagickImage: PlatformImage {
 
     /// Initialize MagickWand.
     private static let genesis: Void = {
+        MagickImage.configureResourcePolicy()
         MagickWandGenesis()
     }()
+
+    // Relax ImageMagick's resource policy.
+    private static func configureResourcePolicy() {
+        let configDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("incontext-imagemagick-policy", isDirectory: true)
+        let policyURL = configDirectory.appendingPathComponent("policy.xml")
+        let policy = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <policymap>
+          <policy domain="resource" name="memory" value="4GiB"/>
+          <policy domain="resource" name="map" value="8GiB"/>
+          <policy domain="resource" name="disk" value="8GiB"/>
+        </policymap>
+        """
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try policy.write(to: policyURL, atomically: true, encoding: .utf8)
+        setenv("MAGICK_CONFIGURE_PATH", configDirectory.path, 1)
+    }
 
     private let wand: OpaquePointer
 

--- a/Sources/InContextCore/Importers/MagickImage.swift
+++ b/Sources/InContextCore/Importers/MagickImage.swift
@@ -1,8 +1,73 @@
+// MIT License
+//
+// Copyright (c) 2016-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #if canImport(CMagickWand)
 
 import Foundation
+import Glibc
 
 import CMagickWand
+
+actor MagicWand {
+
+    var isInitialized = false
+
+    init() {
+
+    }
+
+    func initialize() throws {
+        try configureResourcePolicy()
+        MagickWandGenesis()
+    }
+
+    private func configureResourcePolicy() throws {
+        guard !isInitialized else {
+            return
+        }
+        isInitialized = true
+        let configDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("incontext-imagemagick-policy", isDirectory: true)
+        let policyURL = configDirectory.appendingPathComponent("policy.xml")
+        let policy = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <policymap>
+          <policy domain="resource" name="memory" value="4GiB"/>
+          <policy domain="resource" name="map" value="8GiB"/>
+          <policy domain="resource" name="disk" value="8GiB"/>
+        </policymap>
+        """
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try policy.write(to: policyURL, atomically: true, encoding: .utf8)
+        setenv("MAGICK_CONFIGURE_PATH", configDirectory.path, 1)
+    }
+
+}
+
+let magicWand = MagicWand()
+
+func initializeMagicWand() async throws {
+    try await magicWand.initialize()
+}
 
 final class MagickImage: PlatformImage {
 
@@ -32,8 +97,8 @@ final class MagickImage: PlatformImage {
 
     private let wand: OpaquePointer
 
-    init(url: URL) throws {
-        _ = MagickImage.genesis
+    init(url: URL) async throws {
+        try await initializeMagicWand()
         guard let wand = NewMagickWand() else {
             throw InContextError.allocationFailure
         }

--- a/Sources/InContextCore/Importers/MagickImage.swift
+++ b/Sources/InContextCore/Importers/MagickImage.swift
@@ -62,7 +62,7 @@ actor MagicWand {
         guard isInitialized else {
             return
         }
-        MagicWandTerminus()
+        MagickWandTerminus()
     }
 
 }

--- a/Sources/InContextCore/Importers/PlatformImage.swift
+++ b/Sources/InContextCore/Importers/PlatformImage.swift
@@ -26,7 +26,7 @@ import PlatformSupport
 
 protocol PlatformImage {
 
-    init(url: URL) throws
+    init(url: URL) async throws
 
     var size: Size? { get throws }
     var dateTimeOriginal: Date? { get throws }

--- a/Tests/InContextTests/Resources/hero-open.jpg
+++ b/Tests/InContextTests/Resources/hero-open.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32f6fb2e08e2038455846bec35367d4950b0a44a04f4909d7acb43cc39569dc2
+size 17315700

--- a/Tests/InContextTests/Tests/ImageImporterTests.swift
+++ b/Tests/InContextTests/Tests/ImageImporterTests.swift
@@ -90,7 +90,7 @@ steps:
         XCTAssert(FileManager.default.fileExists(at: thumbnailURL))
 
         // Check the number of frames in the image.
-        let thumbnail = try NativeImage(url: thumbnailURL)
+        let thumbnail = try await NativeImage(url: thumbnailURL)
         XCTAssertEqual(thumbnail.frameCount, 14)
     }
 

--- a/Tests/InContextTests/Tests/PlatformImageTests.swift
+++ b/Tests/InContextTests/Tests/PlatformImageTests.swift
@@ -132,10 +132,11 @@ class PlatformImageTests: ContentTestCase {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<40 {
                 group.addTask {
-                    let image = try NativeImage(url: url)
-                    let dest = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).jpg")
-                    try image.write(maxPixelSize: 1600, format: .jpeg, to: dest)
-                    try? FileManager.default.removeItem(at: dest)
+                    try await withTemporaryDirectory { url in
+                        let destinationURL = url.appendingPathComponent("image.jpeg")
+                        let image = try NativeImage(url: url)
+                        try image.write(maxPixelSize: 1600, format: .jpeg, to: destinationURL)
+                    }
                 }
             }
             try await group.waitForAll()

--- a/Tests/InContextTests/Tests/PlatformImageTests.swift
+++ b/Tests/InContextTests/Tests/PlatformImageTests.swift
@@ -27,45 +27,45 @@ import XCTest
 
 class PlatformImageTests: ContentTestCase {
 
-    func testPixelDimensions() throws {
+    func testPixelDimensions() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         let size = try XCTUnwrap(image.size)
         XCTAssertEqual(size.width, 4032)
         XCTAssertEqual(size.height, 3024)
     }
 
-    func testDateTimeOriginal() throws {
+    func testDateTimeOriginal() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         XCTAssertEqual(try image.dateTimeOriginal, Date(2023, 04, 12, 11, 08, 27))
     }
 
-    func testLocation() throws {
+    func testLocation() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         let latitude = try XCTUnwrap(image.signedLatitude)
         let longitude = try XCTUnwrap(image.signedLongitude)
         XCTAssertEqual(latitude, 64.142272166666672, accuracy: 0.0001)
         XCTAssertEqual(longitude, -21.927391666666665, accuracy: 0.0001)
     }
 
-    func testMediaDescription() throws {
+    func testMediaDescription() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         let description = try XCTUnwrap(image.mediaDescription)
         XCTAssert(description.contains("Hallgrímskirkja Church"))
     }
 
-    func testProjectionType() throws {
+    func testProjectionType() async throws {
         let url = try bundle.throwingURL(forResource: "R0010239", withExtension: "JPG")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         XCTAssertEqual(try image.projectionType, "equirectangular")
     }
 
-    func testMetadataForImageWithReadWarnings() throws {
+    func testMetadataForImageWithReadWarnings() async throws {
         let url = try bundle.throwingURL(forResource: "threshold", withExtension: "png")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         XCTAssertNil(try image.dateTimeOriginal)
         XCTAssertNil(try image.dateTimeDigitized)
         XCTAssertNil(try image.firstTitle)
@@ -75,66 +75,66 @@ class PlatformImageTests: ContentTestCase {
         XCTAssertNil(try image.projectionType)
     }
 
-    func testFrameCountForStillImage() throws {
+    func testFrameCountForStillImage() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         XCTAssertEqual(image.frameCount, 1)
     }
 
-    func testFrameCountForAnimatedGif() throws {
+    func testFrameCountForAnimatedGif() async throws {
         let url = try bundle.throwingURL(forResource: "nezumi_anim", withExtension: "gif")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         XCTAssertEqual(image.frameCount, 14)
     }
 
-    func testResizesImage() throws {
+    func testResizesImage() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
 
         let destinationURL = directoryURL.appendingPathComponent("thumbnail.jpeg")
         try image.write(maxPixelSize: 400, format: .jpeg, to: destinationURL)
         XCTAssert(FileManager.default.fileExists(at: destinationURL))
 
-        let thumbnail = try NativeImage(url: destinationURL)
+        let thumbnail = try await NativeImage(url: destinationURL)
         let size = try XCTUnwrap(thumbnail.size)
         XCTAssertEqual(max(size.width, size.height), 400)
     }
 
-    func testHeicPixelDimensions() throws {
+    func testHeicPixelDimensions() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "heic")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         let size = try XCTUnwrap(image.size)
         XCTAssertEqual(size.width, 4032)
         XCTAssertEqual(size.height, 3024)
     }
 
-    func testHeicDateTimeOriginal() throws {
+    func testHeicDateTimeOriginal() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "heic")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
         XCTAssertEqual(try image.dateTimeOriginal, Date(2023, 04, 12, 11, 08, 27))
     }
 
-    func testResizesHeicImage() throws {
+    func testResizesHeicImage() async throws {
         let url = try bundle.throwingURL(forResource: "IMG_0581", withExtension: "heic")
-        let image = try NativeImage(url: url)
+        let image = try await NativeImage(url: url)
 
         let destinationURL = directoryURL.appendingPathComponent("thumbnail.jpeg")
         try image.write(maxPixelSize: 400, format: .jpeg, to: destinationURL)
         XCTAssert(FileManager.default.fileExists(at: destinationURL))
 
-        let thumbnail = try NativeImage(url: destinationURL)
+        let thumbnail = try await NativeImage(url: destinationURL)
         let size = try XCTUnwrap(thumbnail.size)
         XCTAssertEqual(max(size.width, size.height), 400)
     }
 
     func testConcurrentImports() async throws {
-        let url = try bundle.throwingURL(forResource: "hero-open", withExtension: "jpg")
+        let sourceURL = try bundle.throwingURL(forResource: "hero-open", withExtension: "jpg")
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<40 {
                 group.addTask {
                     try await withTemporaryDirectory { url in
                         let destinationURL = url.appendingPathComponent("image.jpeg")
-                        let image = try NativeImage(url: url)
+                        let image = try await NativeImage(url: sourceURL)
                         try image.write(maxPixelSize: 1600, format: .jpeg, to: destinationURL)
                     }
                 }

--- a/Tests/InContextTests/Tests/PlatformImageTests.swift
+++ b/Tests/InContextTests/Tests/PlatformImageTests.swift
@@ -127,4 +127,19 @@ class PlatformImageTests: ContentTestCase {
         XCTAssertEqual(max(size.width, size.height), 400)
     }
 
+    func testConcurrentImports() async throws {
+        let url = try bundle.throwingURL(forResource: "hero-open", withExtension: "jpg")
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<40 {
+                group.addTask {
+                    let image = try NativeImage(url: url)
+                    let dest = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).jpg")
+                    try image.write(maxPixelSize: 1600, format: .jpeg, to: dest)
+                    try? FileManager.default.removeItem(at: dest)
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
 }

--- a/Tests/InContextTests/Tests/PlatformVideoTests.swift
+++ b/Tests/InContextTests/Tests/PlatformVideoTests.swift
@@ -76,7 +76,7 @@ class PlatformVideoTests: ContentTestCase {
         try await video.writeThumbnail(at: 1, maxPixelSize: 400, format: .jpeg, to: destinationURL)
         XCTAssert(FileManager.default.fileExists(at: destinationURL))
 
-        let thumbnail = try NativeImage(url: destinationURL)
+        let thumbnail = try await NativeImage(url: destinationURL)
         let size = try XCTUnwrap(thumbnail.size)
         // AVAssetImageGenerator.maximumSize is a bounding box, not an exact fit, so the encoder's
         // even-dimension rounding can land a pixel or two under the requested size.

--- a/Tests/InContextTests/Utilities/SourceDirectory.swift
+++ b/Tests/InContextTests/Utilities/SourceDirectory.swift
@@ -26,14 +26,20 @@ import Yams
 
 @testable import InContextCore
 
-func withTemporarySourceDirectory(perform: (SourceDirectory) async throws -> Void) async throws {
+func withTemporaryDirectory(perform: (URL) async throws -> Void) async throws {
     let directoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
     defer {
         try! FileManager.default.removeItem(at: directoryURL)
     }
-    let sourceDirectory = try SourceDirectory(rootURL: directoryURL.real())
-    try await perform(sourceDirectory)
+    try await perform(directoryURL)
+}
+
+func withTemporarySourceDirectory(perform: (SourceDirectory) async throws -> Void) async throws {
+    try await withTemporaryDirectory { directoryURL in
+        let sourceDirectory = try SourceDirectory(rootURL: directoryURL.real())
+        try await perform(sourceDirectory)
+    }
 }
 
 class SourceDirectory {


### PR DESCRIPTION
This change also improves the correctness around `MagickWandGenesis`/`MagickWandTerminus` calls.