### PR TITLE
fix: 📐 Ensure portrait iPhone videos render correctly

### DIFF
--- a/Sources/CAVFormat/shim.h
+++ b/Sources/CAVFormat/shim.h
@@ -21,5 +21,7 @@
 // SOFTWARE.
 
 #include <libavformat/avformat.h>
+#include <libavcodec/packet.h>
 #include <libavutil/avutil.h>
 #include <libavutil/dict.h>
+#include <libavutil/display.h>

--- a/Sources/CGStreamer/shim.h
+++ b/Sources/CGStreamer/shim.h
@@ -36,6 +36,14 @@ static inline void incontext_playbin_set_audio_sink(GstElement *playbin, GstElem
     g_object_set(playbin, "audio-sink", sink, NULL);
 }
 
+static inline void incontext_playbin_set_video_filter(GstElement *playbin, GstElement *filter) {
+    g_object_set(playbin, "video-filter", filter, NULL);
+}
+
+static inline void incontext_videoflip_set_direction_auto(GstElement *videoflip) {
+    gst_util_set_object_arg(G_OBJECT(videoflip), "video-direction", "auto");
+}
+
 static inline GstSample *incontext_playbin_convert_sample(GstElement *playbin, GstCaps *caps) {
     GstSample *sample = NULL;
     g_signal_emit_by_name(playbin, "convert-sample", caps, &sample);

--- a/Sources/InContextCore/Importers/AVFormatVideoMetadata.swift
+++ b/Sources/InContextCore/Importers/AVFormatVideoMetadata.swift
@@ -26,6 +26,13 @@ import Foundation
 
 import CAVFormat
 
+enum VideoOrientation {
+    case up     // Already upright.
+    case down   // Rotated 180°.
+    case left   // Rotated a quarter-turn; upright display requires a 90° clockwise rotation.
+    case right  // Rotated a quarter-turn; upright display requires a 90° counter-clockwise rotation.
+}
+
 final class AVFormatVideoMetadata {
 
     private static func parseDate(_ string: String) -> Date? {
@@ -81,11 +88,50 @@ final class AVFormatVideoMetadata {
         firstCodecParameters(type: AVMEDIA_TYPE_AUDIO) != nil
     }
 
+    var orientation: VideoOrientation {
+        guard let codecpar = videoCodecParameters,
+              let sideData = codecpar.pointee.coded_side_data
+        else {
+            return .up
+        }
+        for index in 0..<Int(codecpar.pointee.nb_coded_side_data) {
+            let entry = sideData[index]
+            guard entry.type == AV_PKT_DATA_DISPLAYMATRIX, let data = entry.data else {
+                continue
+            }
+            let counterclockwise = data.withMemoryRebound(to: Int32.self, capacity: 9) { matrix in
+                av_display_rotation_get(matrix)
+            }
+            guard counterclockwise.isFinite else {
+                return .up
+            }
+            let clockwise = ((Int((-counterclockwise).rounded()) % 360) + 360) % 360
+            switch clockwise {
+            case 90:
+                return .left
+            case 180:
+                return .down
+            case 270:
+                return .right
+            default:
+                return .up
+            }
+        }
+        return .up
+    }
+
     var size: Size? {
         guard let codecpar = videoCodecParameters else {
             return nil
         }
-        return Size(width: Int(codecpar.pointee.width), height: Int(codecpar.pointee.height))
+        let width = Int(codecpar.pointee.width)
+        let height = Int(codecpar.pointee.height)
+        switch orientation {
+        case .up, .down:
+            return Size(width: width, height: height)
+        case .left, .right:
+            return Size(width: height, height: width)
+        }
     }
 
     var duration: Double? {

--- a/Sources/InContextCore/Importers/AVFoundationVideo.swift
+++ b/Sources/InContextCore/Importers/AVFoundationVideo.swift
@@ -47,10 +47,13 @@ final class AVFoundationVideo: PlatformVideo {
 
     var size: Size? {
         get async throws {
-            guard let naturalSize = try await videoTrack?.load(.naturalSize) else {
+            guard let videoTrack = try await videoTrack else {
                 return nil
             }
-            return Size(naturalSize)
+            let naturalSize = try await videoTrack.load(.naturalSize)
+            let preferredTransform = try await videoTrack.load(.preferredTransform)
+            let displaySize = naturalSize.applying(preferredTransform)
+            return Size(CGSize(width: abs(displaySize.width), height: abs(displaySize.height)))
         }
     }
 

--- a/Sources/InContextCore/Importers/GStreamerVideo.swift
+++ b/Sources/InContextCore/Importers/GStreamerVideo.swift
@@ -76,6 +76,15 @@ final class GStreamerVideo: PlatformVideo {
         self.metadata = try AVFormatVideoMetadata(url: url)
     }
 
+    private var requiresRotation: Bool {
+        switch metadata.orientation {
+        case .up:
+            return false
+        case .down, .left, .right:
+            return true
+        }
+    }
+
     var size: Size? {
         get async throws { metadata.size }
     }
@@ -125,6 +134,14 @@ final class GStreamerVideo: PlatformVideo {
             throw InContextError.videoLibraryError("Failed to create fakesink for audio.")
         }
         incontext_playbin_set_audio_sink(playbin, audioSink)
+
+        if requiresRotation {
+            guard let videoFilter = gst_element_factory_make("videoflip", nil) else {
+                throw InContextError.videoLibraryError("Failed to create videoflip filter.")
+            }
+            incontext_videoflip_set_direction_auto(videoFilter)
+            incontext_playbin_set_video_filter(playbin, videoFilter)
+        }
 
         guard let bus = gst_element_get_bus(playbin) else {
             throw InContextError.videoLibraryError("Failed to get pipeline bus.")
@@ -182,8 +199,9 @@ final class GStreamerVideo: PlatformVideo {
         defer { g_free(uri) }
 
         // Video processing pipeline.
+        let videoFlip = requiresRotation ? "videoflip video-direction=auto ! " : ""
         let videoBranch = """
-        d. ! queue ! videoconvert ! videoscale ! videorate ! video/x-raw,width=\(width),height=\(height) ! \
+        d. ! queue ! \(videoFlip)videoconvert ! videoscale ! videorate ! video/x-raw,width=\(width),height=\(height) ! \
         openh264enc ! h264parse ! queue ! mux.video_0
         """
 

--- a/Tests/InContextTests/Resources/IMG_0022.mov
+++ b/Tests/InContextTests/Resources/IMG_0022.mov
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35e538a063591ed8a48ca1f36d00cd1b3c3c886fbc595fb3a84c3301025e9050
+size 1658412

--- a/Tests/InContextTests/Tests/PlatformVideoTests.swift
+++ b/Tests/InContextTests/Tests/PlatformVideoTests.swift
@@ -140,4 +140,46 @@ class PlatformVideoTests: XCTestCase {
         }
     }
 
+    func testReportsOrientedPortraitDimensions() async throws {
+        let url = try bundle.throwingURL(forResource: "IMG_0022", withExtension: "mov")
+        let video = try await NativeVideo(url: url)
+        let unwrappedSize = try await video.size
+        let size = try XCTUnwrap(unwrappedSize)
+        XCTAssertEqual(size.width, 480)
+        XCTAssertEqual(size.height, 640)
+    }
+
+    func testWritesPortraitThumbnail() async throws {
+        try await withTemporaryDirectory { directoryURL in
+            let url = try bundle.throwingURL(forResource: "IMG_0022", withExtension: "mov")
+            let video = try await NativeVideo(url: url)
+
+            let destinationURL = directoryURL.appendingPathComponent("thumbnail.jpeg")
+            try await video.writeThumbnail(at: 1, maxPixelSize: 400, format: .jpeg, to: destinationURL)
+            XCTAssert(FileManager.default.fileExists(at: destinationURL))
+
+            let thumbnail = try await NativeImage(url: destinationURL)
+            let size = try XCTUnwrap(thumbnail.size)
+            XCTAssertGreaterThan(size.height, size.width)
+            XCTAssertEqual(Double(size.width) / Double(size.height), 480.0 / 640.0, accuracy: 0.02)
+        }
+    }
+
+    func testWritesPortraitVideo() async throws {
+        try await withTemporaryDirectory { directoryURL in
+            let url = try bundle.throwingURL(forResource: "IMG_0022", withExtension: "mov")
+            let video = try await NativeVideo(url: url)
+
+            let destinationURL = directoryURL.appendingPathComponent("video.mov")
+            try await video.writeVideo(maxPixelSize: 640, format: .quickTimeMovie, to: destinationURL)
+            XCTAssert(FileManager.default.fileExists(at: destinationURL))
+
+            let transcoded = try await NativeVideo(url: destinationURL)
+            let transcodedSize = try await transcoded.size
+            let size = try XCTUnwrap(transcodedSize)
+            XCTAssertGreaterThan(size.height, size.width)
+            XCTAssertEqual(Double(size.width) / Double(size.height), 480.0 / 640.0, accuracy: 0.02)
+        }
+    }
+
 }


### PR DESCRIPTION
This change ensures we bake in the orientation from the video metadata.